### PR TITLE
Add 'include_resources' option to bdist_mac stage

### DIFF
--- a/cx_setup.py
+++ b/cx_setup.py
@@ -4,8 +4,16 @@ from mkings.constants import VERSION
 
 build_exe_options = {
     "packages": ["pygame", "random", "sys"],
-    "include_files": ["icon.ico", "fonts/", "images/", "sounds/"],
     "excludes": ["tkinter"]
+}
+
+bdist_mac_options = {
+    "include_resources": [
+        ("icon.ico", "icon.ico"),
+        ("fonts", "fonts"),
+        ("images", "images"),
+        ("sounds", "sounds"),
+    ],
 }
 
 base = None
@@ -17,6 +25,9 @@ setup(
     version=f"{VERSION}",
     author="G. Scary T.",
     description="Memory Kings in Python 3",
-    options={"build_exe": build_exe_options},
+    options={
+        "build_exe": build_exe_options,
+        "bdist_mac": bdist_mac_options,
+    },
     executables=[Executable("memorykings.py", base=base, icon="icon.ico")],
 )


### PR DESCRIPTION
When we run 'bdist_dmg' it runs several steps include 'bdist_mac' which
has options for including resources in the final bundle.

This seems to include them appropriately but the final bundle still
isn't finding them and I'm not sure why.